### PR TITLE
KP-9492 Add modifier for adding UHEL as distribution rights holder

### DIFF
--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -19,7 +19,8 @@ class AddDistributionRightsHolderModifier(BaseModifier):
         :param modified_identifiers: Identifiers (e.g. "urn:nbn:fi:lb-123") that specify which
                                      records should be modified. Records whose identifier is not
                                      found in the list are not altered. The identifier is
-                                     assumed to be found in "//cmd:Header/cmd:MdSelfLink/text()".
+                                     assumed to be found in MdSelfLink field in the
+                                     header.
         :type modified_identifiers: list
         :param distribution_rights_holder_str: String representing the XML content to be inserted as
                                                publisher
@@ -81,7 +82,7 @@ class UhelDistributionRightsHolderModifier(AddDistributionRightsHolderModifier):
                 <organizationName xml:lang="en">University of Helsinki</organizationName>
                 <organizationShortName xml:lang="en">UHEL</organizationShortName>
                 <communicationInfo>
-                    <email>firstname.surname@helsinki.fi</email>
+                    <email>fin-clarin@helsinki.fi</email>
                 </communicationInfo>
             </organizationInfo>
         </distributionRightsHolderOrganization>

--- a/update_cmdi.py
+++ b/update_cmdi.py
@@ -8,6 +8,7 @@ import requests
 from sickle import Sickle
 
 from modifiers.lb_modifiers import (
+    UhelDistributionRightsHolderModifier,
     AddOrganizationForPersonModifier,
     FinclarinPersonToOrganizationModifier,
     LanguageBankPersonToOrganizationModifier,
@@ -60,6 +61,16 @@ def selected_modifiers(click_context):
 
     if click_context.params["language_bank_to_organization"]:
         modifiers.append(LanguageBankPersonToOrganizationModifier())
+
+    if click_context.params["uhel_distribution_rights_holder_for"]:
+        identifier_filename = click_context.params[
+            "uhel_distribution_rights_holder_for"
+        ]
+        with open(identifier_filename, "r") as identifier_file:
+            identifiers = [
+                identifier.strip() for identifier in identifier_file.readlines()
+            ]
+        modifiers.append(UhelDistributionRightsHolderModifier(identifiers))
 
     return modifiers
 
@@ -182,6 +193,14 @@ def xml_string_diff(original_record_string, modified_record_string):
     help="URL of the API for modifying records. Comedi endpoints are assumed",
 )
 @click.option(
+    "--uhel-distribution-rights-holder-for",
+    type=click.Path(exists=True),
+    help=(
+        "Add UHEL as distribution rights holder for a hard-coded list of "
+        "corpora that are really published by LBF."
+    ),
+)
+@click.option(
     "--finclarin-to-organization",
     is_flag=True,
     help=(
@@ -234,6 +253,7 @@ def update_metadata(
     set_id,
     oai_pmh_url,
     api_url,
+    uhel_distribution_rights_holder_for,
     finclarin_to_organization,
     language_bank_to_organization,
     add_affiliations_from,


### PR DESCRIPTION
We have a manually curated list of corpora that are published by the Language Bank of Finland but do not have distribution rights holder information available in Comedi. This modifier allows adding the missing information.