### PR TITLE
KP-9803 Add resource creators based on Portal DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 conf/*
 !conf/example_*
 originals/*
+data/*

--- a/conf/example_creators.json
+++ b/conf/example_creators.json
@@ -1,0 +1,17 @@
+{
+  "urn:nbn:fi:lb-2016042710": {
+    "lyhenne": "acquis-ftb3",
+    "tekija": "{Euroopan komission yhteinen tutkimuskeskus (JRC)}",
+    "author": "{European Commission - Joint Research Centre (JRC)}"
+  },
+  "urn:nbn:fi:lb-000000000": {
+    "lyhenne": "example-corpus",
+    "tekija": "Tiina Tutkija; Kiira Korpuksentekijä",
+    "author": "Tiina Tutkija; Kiira Korpuksentekijä"
+  },
+  "urn:nbn:fi:lb-2019121804": {
+    "lyhenne": "agricola-v1-1-korp",
+    "tekija": "",
+    "author": ""
+  }
+}

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -232,10 +232,6 @@ class AddCreatorFromJsonModifier(BaseModifier):
             )
             return False
 
-        if not author_infos:
-            print(f"No authors parsed for {author_dict['lyhenne']}", file=sys.stderr)
-            return False
-
         resource_creation_info = lxml.etree.fromstring(
             """
             <resourceCreationInfo  xmlns="http://www.clarin.eu/cmd/">

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -191,6 +191,7 @@ class AddCreatorFromJsonModifier(BaseModifier):
                 f"/ {identifier}, skipping",
                 file=sys.stderr,
             )
+            return False
 
         authors_en = author_dict["author"].split(";")
         authors_fi = author_dict["tekija"].split(";")

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -143,7 +143,7 @@ class AddCreatorFromJsonModifier(BaseModifier):
 
         author_infos = []
         for author_en, author_fi in zip(authors_en, authors_fi):
-            if not author_en:
+            if not author_en and not author_fi:
                 # empty strings can be skipped right away
                 continue
 

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -152,10 +152,18 @@ class AddCreatorFromJsonModifier(BaseModifier):
             )
             if organization_info is not None:
                 author_infos.append(organization_info)
-            else:
-                person_info = self._person_element(cmdi_record, author_en, author_fi)
-                if person_info is not None:
-                    author_infos.append(person_info)
+                continue
+
+            person_info = self._person_element(cmdi_record, author_en, author_fi)
+            if person_info is not None:
+                author_infos.append(person_info)
+                continue
+
+            print(
+                f"Could not map author {author_fi} / {author_en} for {identifier}, "
+                "skipping the record."
+            )
+            return False
 
         if not author_infos:
             print(f"No authors parsed for {author_dict['lyhenne']}")

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -199,7 +199,7 @@ class AddCreatorFromJsonModifier(BaseModifier):
         if len(authors_en) != len(authors_fi):
             print(
                 "Different number of authors in Finnish and English for "
-                f"{author_dict['lyhenne']}",
+                f"{author_dict['lyhenne']} / {identifier}",
                 file=sys.stderr,
             )
             return False

--- a/modifiers/lb_modifiers.py
+++ b/modifiers/lb_modifiers.py
@@ -204,11 +204,14 @@ class AddCreatorFromJsonModifier(BaseModifier):
             )
             return False
 
+        if not authors_en and not authors_fi:
+            print(
+                f"No author information available for {author_dict['lyhenne']} / {identifier}"
+            )
+            return False
+
         author_infos = []
         for author_en, author_fi in zip(authors_en, authors_fi):
-            if not author_en and not author_fi:
-                # empty strings can be skipped right away
-                continue
 
             organization_info = self._organization_element(
                 cmdi_record, author_en, author_fi

--- a/update_cmdi.py
+++ b/update_cmdi.py
@@ -12,6 +12,7 @@ from modifiers.lb_modifiers import (
     AddOrganizationForPersonModifier,
     FinclarinPersonToOrganizationModifier,
     LanguageBankPersonToOrganizationModifier,
+    AddCreatorFromJsonModifier,
 )
 
 
@@ -55,6 +56,16 @@ def selected_modifiers(click_context):
                         organization_info_str=affiliation["organization_info_str"],
                     )
                 )
+
+    if click_context.params["add_creators_from"]:
+        creator_filename = click_context.params["add_creators_from"]
+        with open(creator_filename, "r") as creator_file:
+            creators = json.loads(creator_file.read())
+            modifiers.append(
+                AddCreatorFromJsonModifier(
+                    creator_dicts=creators,
+                )
+            )
 
     if click_context.params["finclarin_to_organization"]:
         modifiers.append(FinclarinPersonToOrganizationModifier())
@@ -226,6 +237,14 @@ def xml_string_diff(original_record_string, modified_record_string):
     ),
 )
 @click.option(
+    "--add-creators-from",
+    type=click.Path(exists=True),
+    help=(
+        "Path to json file specifying persons/organizations to be added as resource"
+        "creator. See conf/example_creators.json for template."
+    ),
+)
+@click.option(
     "--save-originals-to",
     type=click.Path(
         file_okay=False, dir_okay=True, exists=True, path_type=pathlib.Path
@@ -257,6 +276,7 @@ def update_metadata(
     finclarin_to_organization,
     language_bank_to_organization,
     add_affiliations_from,
+    add_creators_from,
     live_update,
     save_originals_to,
     verbose,


### PR DESCRIPTION
We can fill some resource creator fields in Comedi based on the author data in our database in Portal. This newly-added modifier makes that possible in easy cases, meaning that:
- an exact match for the name is already found in pre-existing metadata for the same resource
- the source data seems to be in good integrity (e.g. the same number of authors in Finnish and English)
- names for people can be unambiguously split into first and last name